### PR TITLE
add close method to explicitly free TagFiles

### DIFF
--- a/src/Sound/TagLib.hs
+++ b/src/Sound/TagLib.hs
@@ -22,6 +22,7 @@ module Sound.TagLib (
     -- * TagFile operations
     open,
     save,
+    close,
     
     -- * Tag Operations
     tag,
@@ -136,6 +137,9 @@ open filename = do
 -- |Save changes to a tag
 save :: TagFile -> IO Integer 
 save tagFile = liftM fromIntegral $ withForeignPtr tagFile taglib_file_save
+
+close :: TagFile -> IO ()
+close tagFile = finalizeForeignPtr tagFile
 
 -- |Get a Tag from a TagFile, if it has one
 tag :: TagFile -> IO (Maybe Tag)

--- a/taglib.cabal
+++ b/taglib.cabal
@@ -1,7 +1,7 @@
 Author:         Brandon Bickford
 Maintainer:     Brandon Bickford <bickfordb@gmail.com>
 Name:           taglib
-Version:        0.1.1
+Version:        0.2.0
 Cabal-Version:  >= 1.2
 License:        LGPL
 License-File:   LICENSE


### PR DESCRIPTION
I've added a close method for tagfiles.  Theres actually a couple reasons for this.  One is simply to avoid leaking file handles in the event that the garbage collector doesn't free them up fast enough.  I actually haven't been able to write a test case where this is a problem, but it's still good practice.

The other issue that I actually DID run afoul of, is it's currently easy to write code that, when compiled with `ghc -O` actually frees the TagFile before your done with it.
Consider the following snippet which inserts code into a acid-state database:

``` haskell
insertFile database file = do
  tagFile <- TL.open file
  mTag <- TL.tag $ fromJust tagFile
  let tag = fromJust mTag
  artist <- TL.artist tag
  album <- TL.album tag
  title <- TL.title tag
  genre <- TL.genre tag
  comment <- TL.comment tag
  track <- TL.track tag
  year <- TL.year tag
  update database (AddTrack file artist album title genre comment track year)
  return ()
```

When compiled with optimizations GHC actually realizes that tagFile is never used, and allows it to be GCed, the resulting error is:

```
pure virtual method called
terminate called without an active exception
```

adding an explicit

``` haskell
  close $ fromJust tagFile
```

to that example resolves it.
